### PR TITLE
Full Python version CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,18 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          # - macos-15
-          # - windows-2025
+          - ubuntu-24.04-arm
         py:
           # - "3.10"
           # - "3.11"
           - "3.12"
           - "3.13"
-          # - "3.14"
+          - "3.14"
+        # include:
+        #   - os: macos-latest
+        #     py: "3.14"
+        #   - os: windows-latest
+        #     py: "3.14"
     steps:
       - uses: actions/checkout@v6
       - run: sudo apt-get install libblas-dev liblapack-dev


### PR DESCRIPTION
Activates full Python version matrix on Ubuntu for both `x86_64` and `arm`.