### PR TITLE
Add clang-tidy support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,12 @@
+WarningsAsErrors: "*"
+UseColor: true
+Checks: >
+  *,
+  -llvmlibc*,
+  -altera-unroll-loops,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -fuchsia-default-arguments-calls,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-magic-numbers,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,20 @@ jobs:
           -w /app
           ubuntu
           pip install -e .[lint,test]
+
+  clang-tidy:
+    name: 🐦‍🔥
+    needs: [compliance, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: sudo apt-get install libblas-dev liblapack-dev clang-tidy
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          pip-install: -e .[test]
+          cache: pip
+      - working-directory: test/cpp
+        run: |
+          cmake -S . -B build -DENABLE_CLANG_TIDY=ON -GNinja
+          cmake --build build

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -13,6 +13,8 @@ RUN apt-get update && \
         git \
         build-essential \
         cmake \
+        clang-tidy \
+        cmake-curses-gui \
         ninja-build && \
     rm -rf /var/lib/apt/lists/*
 

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -5,6 +5,14 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(FeatureSummary)
+option(ENABLE_CLANG_TIDY "Run clang-tidy while building" OFF)
+add_feature_info(
+    ENABLE_CLANG_TIDY
+    ENABLE_CLANG_TIDY
+    "Run clang-tidy while building"
+)
+
 add_compile_options(
     -Wall
     -Wextra
@@ -43,6 +51,16 @@ add_custom_target(
 
 add_executable(kernel kernel.cpp)
 add_dependencies(kernel poisson_kernel)
+
+if(ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY NAMES clang-tidy REQUIRED)
+    set_target_properties(
+        kernel
+        PROPERTIES
+            CXX_CLANG_TIDY
+                "${CLANG_TIDY};--config-file=${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy"
+    )
+endif()
 
 target_include_directories(kernel PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(kernel PUBLIC ${FFCX_PATH}/codegeneration)

--- a/test/cpp/kernel.cpp
+++ b/test/cpp/kernel.cpp
@@ -1,3 +1,7 @@
+#include <array>
+#include <complex>
+#include <cstddef>
+
 #include <gtest/gtest.h>
 
 #include "poisson.hpp"
@@ -33,12 +37,12 @@ TYPED_TEST(Kernel, Integral)
   integral_3af066e0aa4a1ce87756d2984331c55a2d3d2f62 integral;
 
   std::array<scalar_t, 9> A{ 0 };
-  const std::array<scalar_t, 0> w;
+  const std::array<scalar_t, 0> w{};
   const std::array<scalar_t, 4> c{ 1, 2, 3, 4 };
   const std::array<geo_t, 9> coords{ 0, 0, 0, 1, 0, 0, 0, 1, 0 };
 
   integral.tabulate_tensor<scalar_t, geo_t>(
-    A.data(), w.data(), c.data(), coords.data(), 0, 0);
+    A.data(), w.data(), c.data(), coords.data(), nullptr, nullptr);
 
   const std::array<scalar_t, 9> A_expected{ 5, -2.5, -2.5, -2.5, 2.5,
                                             0, -2.5, 0,    2.5 };


### PR DESCRIPTION
Add `clang-tidy` support.  Pretty strict config for now - we can adapt on the fly to find a reasonable subset of checks I would suggest.

In particular `misc-include-cleaner` ensures unused imports are removed.

Fixes https://github.com/fenics-dolfiny/ffcx-backends/issues/24.