### PR TITLE
Add `ty` CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-          pip-install: -e .[lint]
+          pip-install: -e .[lint,test]
           cache: pip
       - run: ruff format --diff
       - run: ruff check
@@ -45,6 +45,8 @@ jobs:
           xargs clang-format --dry-run --Werror
       - run: mypy -p ffcx_backends
       - run: mypy test/
+      - run: ty check ffcx_backends/
+      - run: ty check test/
 
   test:
     name: ⚙️

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ Repository = "https://github.com/schnellerhase/ffcx-backends"
 "Bug Tracker" = "https://github.com/schnellerhase/ffcx-backends/issues"
 
 [project.optional-dependencies]
-lint = ["clang-format", "ruff", "yamllint", "mypy"]
+lint = ["clang-format", "ruff", "yamllint", "mypy", "ty"]
 test = ["pytest", "nvidia-cuda-nvrtc-cu12"]
 
 [tool.setuptools]

--- a/test/cuda/test_nvrtc.py
+++ b/test/cuda/test_nvrtc.py
@@ -26,7 +26,7 @@ def test_compiler_bad_source(nvrtc_compiler):
             ["./nvrtc_compiler", cuda_dir / "not_a_file.cu"],
             cwd=build_dir,
         )
-        assert "Could not read file" in error.value
+        assert "Could not read file" in str(error.value)
 
 
 def test_compiler_help(nvrtc_compiler) -> None:
@@ -42,7 +42,7 @@ def test_compiler_arg_count(nvrtc_compiler) -> None:
             ["./nvrtc_compiler", "a", "b"],
             cwd=build_dir,
         )
-        assert "Usage:" in error.value
+        assert "Usage:" in str(error.value)
 
 
 def test_demo_nvrtc(nvrtc_compiler):

--- a/test/test_cpp.py
+++ b/test/test_cpp.py
@@ -1,4 +1,4 @@
-import basix
+import basix.ufl
 import ufl
 from ffcx.compiler import compile_ufl_objects
 from ffcx.options import get_options


### PR DESCRIPTION
Adds a (second) type checker `ty` to the CI checks.

- caught that the previous type checks were not exhaustive, since testing dependencies were not installed. 