### PR TITLE
Cross platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,19 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
-        # include:
-        #   - os: macos-latest
-        #     py: "3.14"
+        include:
+          - os: macos-26 # arm64
+            py: "3.14"
+          - os: macos-26-intel
+            py: "3.14"
         #   - os: windows-latest
         #     py: "3.14"
     steps:
       - uses: actions/checkout@v6
       - run: sudo apt-get install libblas-dev liblapack-dev
+        if: contains(matrix.os, 'ubuntu')
+      - run: brew install openblas lapack
+        if: contains(matrix.os, 'macos')
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,6 @@ jobs:
             py: "3.14"
           - os: macos-26-intel
             py: "3.14"
-        #   - os: windows-latest
-        #     py: "3.14"
     steps:
       - uses: actions/checkout@v6
       - run: sudo apt-get install libblas-dev liblapack-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ Repository = "https://github.com/schnellerhase/ffcx-backends"
 "Bug Tracker" = "https://github.com/schnellerhase/ffcx-backends/issues"
 
 [project.optional-dependencies]
-test = ["pytest", "nvidia-cuda-nvrtc-cu12"]
+test = ["pytest", "nvidia-cuda-nvrtc-cu12 ; platform_system == 'Linux'"]
 
 [dependency-groups]
 format = ["ruff", "yamllint", "typos", "gersemi", "clang-format"]

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -25,7 +25,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG 52eb8108c5bdec04579160ae17225d66034bd723 # 1.17.0
+    GIT_TAG a721f1b20c605f635413e22d8b7427a8b4f3956c # main on 2th June 26
 )
 FetchContent_MakeAvailable(googletest)
 

--- a/test/cuda/test_nvrtc.py
+++ b/test/cuda/test_nvrtc.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("nvidia.cuda_nvrtc", reason="NVRTC not available on all platforms.")
+
 cuda_dir = cuda = Path(__file__).parent
 build_dir = cuda / "nvrtc_compiler" / "build"
 


### PR DESCRIPTION
- `cuda_nvrtc` is now a platform dependant dependency
- CI extended to run also on MacOs (`arm` and `x86`) - skip ⊞ for sanity. 
- bump gtest to current `main` for inclusion of LLVM warning fix https://github.com/google/googletest/commit/fa8438ae6b70c57010177de47a9f13d7041a6328