### PR TITLE
Tidy dependency management

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,5 +40,5 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {}
   },
-  "postCreateCommand": "pip install -e .[lint,test]"
+  "postCreateCommand": "pip install --group format --group lint && pip install -e .[test]"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 6 * * *" # daily at 6am
 
 jobs:
-  compliance:
+  format:
     name: 🔎
     runs-on: ubuntu-latest
     steps:
@@ -20,12 +20,17 @@ jobs:
         with:
           python-version: "3.14"
       - uses: actions/setup-node@v6
-      - run: pip install typos yamllint gersemi
+      - run: pip install --group format
+        working-directory: src
       - run: npm install prettier prettier-plugin-toml
       - run: typos src
       - run: yamllint src
       - run: gersemi --check src
+      - run: ruff format --diff src
       - run: npx prettier . --check --plugin prettier-plugin-toml
+      - run: >
+          find . -type f \( -name "*.cpp" -o -name "*.cu" \) |
+          xargs clang-format --dry-run --Werror
 
   lint:
     name: ✨
@@ -36,13 +41,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-          pip-install: -e .[lint,test]
+          pip-install: -e .[test] --group lint --group format
           cache: pip
-      - run: ruff format --diff
       - run: ruff check
-      - run: >
-          find . -type f \( -name "*.cpp" -o -name "*.cu" \) |
-          xargs clang-format --dry-run --Werror
       - run: mypy -p ffcx_backends
       - run: mypy test/
       - run: ty check ffcx_backends/
@@ -50,7 +51,7 @@ jobs:
 
   test:
     name: ⚙️
-    needs: [compliance, lint]
+    needs: [format]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -86,7 +87,7 @@ jobs:
 
   dev-container:
     name: 🐳
-    needs: [compliance, lint]
+    needs: [format]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -112,7 +113,7 @@ jobs:
 
   clang-tidy:
     name: 🐦‍🔥
-    needs: [compliance, lint]
+    needs: [format]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -21,3 +21,5 @@ RUN apt-get update && \
 RUN python -m venv /opt/venv
 # Enable venv
 ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,11 @@ Repository = "https://github.com/schnellerhase/ffcx-backends"
 "Bug Tracker" = "https://github.com/schnellerhase/ffcx-backends/issues"
 
 [project.optional-dependencies]
-lint = ["clang-format", "ruff", "yamllint", "mypy", "ty"]
 test = ["pytest", "nvidia-cuda-nvrtc-cu12"]
+
+[dependency-groups]
+format = ["ruff", "yamllint", "typos", "gersemi", "clang-format"]
+lint = ["mypy", "ty", "ruff"]
 
 [tool.setuptools]
 packages = ["ffcx_backends"]


### PR DESCRIPTION
- Remove inline dependency definition of formatting job (now all dependencies maintained through `pyproject.toml`)
- Split linting and formatting jobs cleanly (`ruff` and `clang-format` checks moved to format) 
- Linting no longer dependency for CI runs (all jobs only depend on format to pass)

Fixes https://github.com/fenics-dolfiny/ffcx-backends/issues/41.