### PR TITLE
Adapt to gersemi release 

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -25,8 +25,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG
-        52eb8108c5bdec04579160ae17225d66034bd723 # 1.17.0
+    GIT_TAG 52eb8108c5bdec04579160ae17225d66034bd723 # 1.17.0
 )
 FetchContent_MakeAvailable(googletest)
 


### PR DESCRIPTION
`gersemi==0.27.6` changed formatting expectations.